### PR TITLE
[UPD] versionCode from git's tag + basecode (90000000)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,6 +9,11 @@ plugins {
 	id 'com.gladed.androidgitversion' version '0.4.13'
 }
 
+androidGitVersion {
+	baseCode 90000000
+	codeFormat 'MNNPPP'
+}
+
 android {
 	compileSdkVersion 29
 	buildToolsVersion "29.0.3"
@@ -18,10 +23,7 @@ android {
 		minSdkVersion 23
 		targetSdkVersion 29
 		versionName androidGitVersion.name()
-		versionCode 1
-		/* should become but for now github CI isn't happy:
-			versionCode androidGitVersion.code()
-		 */
+		versionCode androidGitVersion.code()
 	}
 
 	flavorDimensions "version"


### PR DESCRIPTION
Fixes #54 

app versionCode is defined through git's tag with codeFormat MNNPPP where
M: major, N minor, P patch version + a baseCode to skip github CI workflow
errors when major number is 0 (see below for error)

GitHub CI workflow error (without baseCode):

Starting a Gradle Daemon (subsequent builds will be faster)

FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':app'.
> android.defaultConfig.versionCode is set to 0, but it should be a positive integer.
  See https://developer.android.com/studio/publish/versioning#appversioning for more information.